### PR TITLE
댓글 페이지 UI 구현

### DIFF
--- a/src/components/common/divider/divider.stories.tsx
+++ b/src/components/common/divider/divider.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Divider from './divider';
+
+const meta = {
+    title: 'Components/Divider',
+    component: Divider,
+    parameters: {
+        size: 6,
+        color: 300,
+    },
+    argTypes: {},
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        size: 6,
+        color: 300,
+    },
+};

--- a/src/components/common/divider/divider.tsx
+++ b/src/components/common/divider/divider.tsx
@@ -1,0 +1,12 @@
+import * as S from './style';
+
+interface IDivider {
+    size?: number;
+    color?: number;
+}
+
+const Divider = ({ size, color }: IDivider) => {
+    return <S.Divider $size={size} $color={color} />;
+};
+
+export default Divider;

--- a/src/components/common/divider/style.ts
+++ b/src/components/common/divider/style.ts
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+export const Divider = styled.div<{ $size?: number; $color?: number }>`
+    width: 100%;
+    height: ${(props) => `${props.$size ? props.$size : 1}px`};
+    background-color: ${(props) => props.theme.color.gray[props.$color || 100]};
+`;

--- a/src/components/common/divider/style.ts
+++ b/src/components/common/divider/style.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
-export const Divider = styled.div<{ $size?: number; $color?: number }>`
+export const Divider = styled.hr<{ $size?: number; $color?: number }>`
     width: 100%;
     height: ${(props) => `${props.$size ? props.$size : 1}px`};
     background-color: ${(props) => props.theme.color.gray[props.$color || 100]};
+    border: none;
 `;

--- a/src/components/common/layout/ContentLayout.tsx
+++ b/src/components/common/layout/ContentLayout.tsx
@@ -1,10 +1,14 @@
+import { useCallback } from 'react';
 import { Outlet } from 'react-router-dom';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import LocationBar from '../locationBar/LocationBar';
 
 const ContentLayout = () => {
     const location = useLocation();
+    const { id } = useParams();
+    const navigate = useNavigate(); //변수 할당시켜서 사용
+
     let headerText = '';
     let asType = '';
 
@@ -14,17 +18,24 @@ const ContentLayout = () => {
             headerText = '글쓰기';
             asType = 'subtitle';
             break;
-        default:
+        case `/contents/${id}`:
             headerText = '글읽기';
             asType = 'back';
+            break;
+        case `/contents/${id}/comment`:
+            headerText = '댓글';
+            asType = 'back';
+            break;
     }
+    const handleMoveBack = useCallback(() => navigate(-1), []);
+
     return (
         <>
             <LocationBar
                 location={headerText}
                 as={asType}
                 onRegister={function (): void {}}
-                onBack={function (): void {}}
+                onBack={handleMoveBack}
             />
             <Outlet />
         </>

--- a/src/components/features/contents/comment/comment.tsx
+++ b/src/components/features/contents/comment/comment.tsx
@@ -1,0 +1,39 @@
+import SubTitle from '@components/common/text/SubTitle';
+import { useCallback, useState } from 'react';
+
+import Input from '@/components/common/Input/Input';
+import CommentContainer from '@/components/features/contents/detail/commentContainer';
+
+import * as S from '../style';
+export interface IButtonData {
+    label: string;
+    color: 'primary' | 'secondary';
+}
+const ContentContainer = () => {
+    const [inputValue, setinputValue] = useState('');
+    const handleValueChange = useCallback((value: string) => {
+        setinputValue(value);
+    }, []);
+
+    const count = '0';
+
+    return (
+        <S.Wrapper>
+            <S.Container>
+                {/* 댓글 영역 */}
+                <S.CommentWrapper detail={true}>
+                    <SubTitle lan='ENG' text={`댓글 ${count}`} />
+                    <CommentContainer />
+                    <Input
+                        placeholder={'댓글을 남겨보세요.'}
+                        as={'Comment'}
+                        value={inputValue}
+                        handleOnChange={handleValueChange}
+                    />
+                </S.CommentWrapper>
+            </S.Container>
+        </S.Wrapper>
+    );
+};
+
+export default ContentContainer;

--- a/src/components/features/contents/comment/comment.tsx
+++ b/src/components/features/contents/comment/comment.tsx
@@ -1,6 +1,7 @@
 import SubTitle from '@components/common/text/SubTitle';
 import { useCallback, useState } from 'react';
 
+import Divider from '@/components/common/divider/divider';
 import Input from '@/components/common/Input/Input';
 import CommentContainer from '@/components/features/contents/detail/commentContainer';
 
@@ -23,13 +24,17 @@ const ContentContainer = () => {
                 {/* 댓글 영역 */}
                 <S.CommentWrapper detail={true}>
                     <SubTitle lan='ENG' text={`댓글 ${count}`} />
+                    <Divider size={6} />
                     <CommentContainer />
-                    <Input
-                        placeholder={'댓글을 남겨보세요.'}
-                        as={'Comment'}
-                        value={inputValue}
-                        handleOnChange={handleValueChange}
-                    />
+                    <S.InputArea>
+                        <Divider color={300} />
+                        <Input
+                            placeholder={'댓글을 남겨보세요.'}
+                            as={'Comment'}
+                            value={inputValue}
+                            handleOnChange={handleValueChange}
+                        />
+                    </S.InputArea>
                 </S.CommentWrapper>
             </S.Container>
         </S.Wrapper>

--- a/src/components/features/contents/detail/commentContainer.tsx
+++ b/src/components/features/contents/detail/commentContainer.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Divider } from '@/components/common/divider/style';
+
 import * as S from '../style';
 import Comment from './commentTheme';
 
@@ -44,6 +46,7 @@ const CommentContainer = () => {
                 <React.Fragment key={data.id}>
                     <S.CommentArea>
                         <Comment nickname={data.nickname} content={data.content} date={data.date} />
+                        <Divider />
                     </S.CommentArea>
                     {data.recomment.map((rec, index) => (
                         <S.CommentArea key={index} paddingLeft={'40px'}>

--- a/src/components/features/contents/detail/detail.tsx
+++ b/src/components/features/contents/detail/detail.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import Button from '@/components/common/Button/Button';
+import Divider from '@/components/common/divider/divider';
 import Input from '@/components/common/Input/Input';
 import ContentTag from '@/components/common/text/ContentTag';
 import CommentContainer from '@/components/features/contents/detail/commentContainer';
@@ -36,10 +37,12 @@ const ContentContainer = () => {
             <S.Container>
                 {/* 타이틀 영역 */}
                 <TitleContainer />
+                <Divider size={6} />
                 {/* 글 영역 */}
                 <S.ContentContainer>
                     <ContentTag as='M' text={content} />
                 </S.ContentContainer>
+                <Divider color={300} />
                 {/* 댓글 영역 */}
                 <S.CommentWrapper onClick={handleMoveComment}>
                     <SubTitle lan='ENG' text={`댓글 ${count}`} />
@@ -51,6 +54,7 @@ const ContentContainer = () => {
                         handleOnChange={handleValueChange}
                     />
                 </S.CommentWrapper>
+                <Divider size={6} />
             </S.Container>
             {/* 버튼 영역 */}
             <S.ButtonWrapper>

--- a/src/components/features/contents/detail/detail.tsx
+++ b/src/components/features/contents/detail/detail.tsx
@@ -1,5 +1,6 @@
 import SubTitle from '@components/common/text/SubTitle';
 import { useCallback, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import Button from '@/components/common/Button/Button';
 import Input from '@/components/common/Input/Input';
@@ -13,10 +14,14 @@ export interface IButtonData {
     color: 'primary' | 'secondary';
 }
 const ContentContainer = () => {
+    const { id } = useParams();
     const [inputValue, setinputValue] = useState('');
     const handleValueChange = useCallback((value: string) => {
         setinputValue(value);
     }, []);
+
+    const navigate = useNavigate();
+    const handleMoveComment = useCallback(() => navigate(`/contents/${id}/comment`), []);
 
     const content =
         '이것은 글의 본문 내용입니다. 이것은 글의 본문 내용입니다. 이것은 글의 본문 내용입니다. 이것은 글의 본문 내용입니다. 이것은 글의 본문 내용입니다.  이것은 글의 본문 내용입니다. ';
@@ -36,7 +41,7 @@ const ContentContainer = () => {
                     <ContentTag as='M' text={content} />
                 </S.ContentContainer>
                 {/* 댓글 영역 */}
-                <S.CommentWrapper>
+                <S.CommentWrapper onClick={handleMoveComment}>
                     <SubTitle lan='ENG' text={`댓글 ${count}`} />
                     <CommentContainer />
                     <Input

--- a/src/components/features/contents/style.ts
+++ b/src/components/features/contents/style.ts
@@ -44,7 +44,6 @@ export const TitleWrapper = styled.div`
     gap: 10px 0;
     display: flex;
     flex-direction: column;
-    border-bottom: 8px solid ${(props) => props.theme.color.gray[100]};
 `;
 export const TopArea = styled.div`
     width: 100%;
@@ -55,36 +54,38 @@ export const TopArea = styled.div`
 export const ContentContainer = styled.div`
     width: 100%;
     padding: 20px 20px 60px 20px;
-    border-bottom: 1px solid ${(props) => props.theme.color.gray[300]};
 `;
 
 export const CommentWrapper = styled.div<{ detail?: boolean }>`
     display: flex;
     flex-direction: column;
     padding: 20px 0;
-    border-bottom: ${(props) => !props.detail && `8px solid ${props.theme.color.gray[100]}`};
     cursor: ${(props) => !props.detail && 'pointer'};
-
+    position: relative;
+    height: ${(props) => props.detail && 'calc(100vh - 56px)'};
     & > h4 {
         padding: 0 20px 20px;
     }
 
-    & > div:nth-of-type(1) {
-        border-top: ${(props) => props.detail && `8px solid ${props.theme.color.gray[100]}`};
-    }
-    & > div:nth-last-child(2) {
-        border-bottom: ${(props) => props.detail && `1px solid ${props.theme.color.gray[300]}`};
-    }
     & > div:has(input) {
-        margin: 10px 20px 0;
+        width: calc(100% - 40px);
+        margin: ${(props) => !props.detail && '10px 20px 0'};
     }
+`;
+
+export const InputArea = styled.div`
+    position: absolute;
+    bottom: 10px;
+    left: 20px;
+    gap: 10px 0;
+    display: flex;
+    flex-direction: column;
 `;
 
 export const CommentArea = styled.div<{ paddingLeft?: string }>`
     display: flex;
     flex-wrap: wrap;
     gap: 12px 0;
-    border-bottom: 1px solid ${(props) => props.theme.color.gray[100]};
     padding: ${(props) =>
         props.paddingLeft ? `16px 20px 16px ${props.paddingLeft}` : '16px 20px'};
 `;

--- a/src/components/features/contents/style.ts
+++ b/src/components/features/contents/style.ts
@@ -58,16 +58,23 @@ export const ContentContainer = styled.div`
     border-bottom: 1px solid ${(props) => props.theme.color.gray[300]};
 `;
 
-export const CommentWrapper = styled.div`
+export const CommentWrapper = styled.div<{ detail?: boolean }>`
     display: flex;
     flex-direction: column;
-    border-bottom: 8px solid ${(props) => props.theme.color.gray[100]};
     padding: 20px 0;
+    border-bottom: ${(props) => !props.detail && `8px solid ${props.theme.color.gray[100]}`};
+    cursor: ${(props) => !props.detail && 'pointer'};
 
     & > h4 {
         padding: 0 20px 20px;
     }
 
+    & > div:nth-of-type(1) {
+        border-top: ${(props) => props.detail && `8px solid ${props.theme.color.gray[100]}`};
+    }
+    & > div:nth-last-child(2) {
+        border-bottom: ${(props) => props.detail && `1px solid ${props.theme.color.gray[300]}`};
+    }
     & > div:has(input) {
         margin: 10px 20px 0;
     }

--- a/src/pages/contents/CommentPage.tsx
+++ b/src/pages/contents/CommentPage.tsx
@@ -1,7 +1,11 @@
-import * as S from '../../components/common/layout/style';
+import Comment from '@/components/features/contents/comment/comment';
 
 const CommentPage = () => {
-    return <S.Container>Comment</S.Container>;
+    return (
+        <>
+            <Comment />
+        </>
+    );
 };
 
 export default CommentPage;


### PR DESCRIPTION
## 📖 관련 문서
#27 

## ✍🏻 변경사항:

![image](https://github.com/ate-eight/sell-your-unhappiness-front/assets/96216178/40355abd-28c3-4eb9-991a-70e040e2f372)
* comment 페이지 UI 구현
   * 댓글 페이지 생성
   *  LocationBar location case 추가 (댓글)
   * 글 상세 페이지 내 댓글 영역 클릭시 댓글페이지로 이동 기능 및 cursor css 추가
   * 글 상세 페이지에 있는 댓글영역과 동일한 컴포넌트를 쓰고 있어 구분을 위해 detail={true} 및 css 추가 
   
## 🔍 확인할 목록
- comment 페이지 ui
- api는 글 상세 페이지 merge 후 붙히겠습니다~!
