### PR TITLE
댓글작성 API Mutation 추가 & 댓글 Style 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,11 +9,9 @@ import theme from './styles/theme';
 export const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
-            throwOnError: true,
             retry: 0,
         },
         mutations: {
-            throwOnError: true,
             retry: 0,
             onError: (error) => console.error(error.message),
         },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,13 @@ import theme from './styles/theme';
 
 export const queryClient = new QueryClient({
     defaultOptions: {
+        queries: {
+            throwOnError: true,
+            retry: 0,
+        },
         mutations: {
+            throwOnError: true,
+            retry: 0,
             onError: (error) => console.error(error.message),
         },
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Router from './router/Router';
 import reset from './styles/reset';
 import theme from './styles/theme';
 
-const queryClient = new QueryClient();
+export const queryClient = new QueryClient();
 function App() {
     return (
         <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,14 @@ import Router from './router/Router';
 import reset from './styles/reset';
 import theme from './styles/theme';
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+    defaultOptions: {
+        mutations: {
+            onError: (error) => console.error(error.message),
+        },
+    },
+});
+
 function App() {
     return (
         <>

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -51,7 +51,6 @@ export const useCommentById = (id: number) => {
     return useSuspenseQuery<ICommentResponse, Error>({
         queryKey: ['comment', id],
         queryFn: () => COMMENT_API.getALL(id),
-        staleTime: 1000 * 60 * 5,
     });
 };
 

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -58,7 +58,6 @@ export const useCommentById = (id: number) => {
 export const useCommentAdd = () => {
     return useMutation({
         mutationFn: (body: ICommentAdd) => COMMENT_API.add(body),
-        onError: (error) => console.error(error.message),
         onSuccess: (res, variables) => {
             const { common } = res;
             if (common.code === 200) {

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -5,12 +5,9 @@ import { fetchData } from '@/api';
 export interface ICommentInfo {
     contents: string;
     id: number;
-    type: string;
-    status: string;
-    title: string;
+    parentId: number;
     content: string;
     createTime: string;
-    modifiedTime: string;
 }
 
 export interface ICommentResponse {

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -2,17 +2,19 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchData } from '@/api';
 
+export interface ICommentInfo {
+    contents: string;
+    id: number;
+    type: string;
+    status: string;
+    title: string;
+    content: string;
+    createTime: string;
+    modifiedTime: string;
+}
+
 export interface ICommentResponse {
-    contents: {
-        contents: string;
-        id: number;
-        type: string;
-        status: string;
-        title: string;
-        content: string;
-        createTime: string;
-        modifiedTime: string;
-    }[];
+    contents: ICommentInfo[];
 }
 
 export const COMMENT_API = {

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
 import { fetchData } from '@/api';
 import { queryClient } from '@/App';
@@ -48,7 +48,7 @@ export const COMMENT_API = {
 };
 
 export const useCommentById = (id: number) => {
-    return useQuery<ICommentResponse, Error>({
+    return useSuspenseQuery<ICommentResponse, Error>({
         queryKey: ['comment', id],
         queryFn: () => COMMENT_API.getALL(id),
         staleTime: 1000 * 60 * 5,

--- a/src/api/contents.ts
+++ b/src/api/contents.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { fetchData } from '@/api';
 
@@ -31,7 +31,7 @@ export const CONTENT_API = {
 };
 
 export const useContentsById = (id: number) => {
-    return useQuery<IContentResponse, Error>({
+    return useSuspenseQuery<IContentResponse, Error>({
         queryKey: ['contents', id],
         queryFn: () => CONTENT_API.getDetail(id),
         staleTime: 60000,

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -17,7 +17,7 @@ const Input = (props: Props) => {
             <S.CommentInputWrapper $height={'51px'}>
                 <S.Input
                     placeholder={placeholder}
-                    defaultValue={value}
+                    value={value}
                     onChange={(e) => handleOnChange?.(e.target.value)}
                 />
                 <S.SubmitButton

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -4,14 +4,14 @@ import * as S from './style';
 interface Props {
     as: 'Default' | 'Comment';
     placeholder: string;
-    value: string;
+    value?: string;
     height?: string;
     handleOnChange?: (value: string) => void;
     handleOnClick?: () => void;
 }
 
 const Input = (props: Props) => {
-    const { as, placeholder, value, handleOnChange, handleOnClick } = props;
+    const { as, placeholder, value = '', handleOnChange, handleOnClick } = props;
     if (as === 'Comment') {
         return (
             <S.CommentInputWrapper $height={'51px'}>

--- a/src/components/features/contents/comment/comment.tsx
+++ b/src/components/features/contents/comment/comment.tsx
@@ -1,11 +1,10 @@
 import SubTitle from '@components/common/text/SubTitle';
-import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { ICommentAdd, useCommentAdd, useCommentById } from '@/api/comment';
 import Divider from '@/components/common/divider/divider';
 import Input from '@/components/common/Input/Input';
 import CommentContainer from '@/components/features/contents/comment/commentContainer';
+import useComment from '@/hooks/useComment';
 
 import * as S from '../style';
 
@@ -15,31 +14,8 @@ export interface IButtonData {
 }
 const ContentContainer = () => {
     const { id } = useParams();
-    const { data: commentsData } = useCommentById(Number(id));
-    const [inputValue, setinputValue] = useState('');
-    const handleValueChange = useCallback((value: string) => {
-        setinputValue(value);
-    }, []);
 
-    const { mutate: addComment, isError, isSuccess } = useCommentAdd();
-
-    /**
-     * react-query mutation으로 query-key update
-     */
-    const handleCommentSubmit = async () => {
-        const obj: ICommentAdd = {
-            boardId: Number(id),
-            content: inputValue,
-        };
-
-        addComment(obj);
-    };
-
-    useEffect(() => {
-        if (!isError && isSuccess) {
-            setinputValue('');
-        }
-    }, [isError, isSuccess]);
+    const { commentsData, inputValue, handleValueChange, handleCommentSubmit } = useComment(id);
 
     return (
         <S.Wrapper>

--- a/src/components/features/contents/comment/comment.tsx
+++ b/src/components/features/contents/comment/comment.tsx
@@ -22,10 +22,10 @@ const ContentContainer = () => {
             <S.Container>
                 {/* 댓글 영역 */}
                 <S.CommentWrapper detail={true}>
-                    <SubTitle lan='ENG' text={`댓글 ${commentsData?.contents.length}`} />
+                    <SubTitle lan='ENG' text={`댓글 ${commentsData?.contents.length ?? 0}`} />
                     <Divider size={6} />
 
-                    {commentsData && <CommentContainer commentsData={commentsData} />}
+                    <CommentContainer commentsData={commentsData} />
                     <S.InputArea>
                         <Divider color={300} />
                         <Input

--- a/src/components/features/contents/comment/comment.tsx
+++ b/src/components/features/contents/comment/comment.tsx
@@ -1,18 +1,13 @@
 import SubTitle from '@components/common/text/SubTitle';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { fetchData } from '@/api';
-import { useCommentById } from '@/api/comment';
+import { ICommentAdd, useCommentAdd, useCommentById } from '@/api/comment';
 import Divider from '@/components/common/divider/divider';
 import Input from '@/components/common/Input/Input';
 import CommentContainer from '@/components/features/contents/comment/commentContainer';
 
 import * as S from '../style';
-
-interface ICommentAddResponse {
-    message: string;
-}
 
 export interface IButtonData {
     label: string;
@@ -26,33 +21,25 @@ const ContentContainer = () => {
         setinputValue(value);
     }, []);
 
+    const { mutate: addComment, isError, isSuccess } = useCommentAdd();
+
     /**
      * react-query mutation으로 query-key update
      */
     const handleCommentSubmit = async () => {
-        alert('댓글 저장');
+        const obj: ICommentAdd = {
+            boardId: Number(id),
+            content: inputValue,
+        };
 
-        if (!inputValue) return;
-
-        const response = await fetchData.post<ICommentAddResponse>(
-            '/v1/board-comment',
-            JSON.stringify({
-                // parentId: 0,
-                boardId: 1,
-                content: inputValue,
-            }),
-        );
-
-        if (response) {
-            const { data, common } = response.data;
-
-            if (common.success) {
-                console.log(data);
-            } else {
-                console.error(common.message);
-            }
-        }
+        addComment(obj);
     };
+
+    useEffect(() => {
+        if (!isError && isSuccess) {
+            setinputValue('');
+        }
+    }, [isError, isSuccess]);
 
     return (
         <S.Wrapper>

--- a/src/components/features/contents/comment/commentContainer.tsx
+++ b/src/components/features/contents/comment/commentContainer.tsx
@@ -1,4 +1,4 @@
-import { ICommentResponse } from '@/api/comment';
+import { ICommentInfo, ICommentResponse } from '@/api/comment';
 
 import * as S from '../style';
 import Comment from './commentTheme';
@@ -12,7 +12,7 @@ const CommentContainer = ({ commentsData }: ICommentProps) => {
         <>
             {commentsData &&
                 Array.isArray(commentsData.contents) && // Check if contents is an array
-                commentsData.contents.map((comment: ICommentResponse) => (
+                commentsData.contents.map((comment: ICommentInfo) => (
                     <S.CommentArea key={comment.id}>
                         <Comment commentsData={comment} />
                     </S.CommentArea>

--- a/src/components/features/contents/comment/commentContainer.tsx
+++ b/src/components/features/contents/comment/commentContainer.tsx
@@ -8,15 +8,15 @@ interface ICommentProps {
 }
 
 const CommentContainer = ({ commentsData }: ICommentProps) => {
+    if (!Array.isArray(commentsData.contents) && commentsData) return;
+
     return (
         <>
-            {commentsData &&
-                Array.isArray(commentsData.contents) && // Check if contents is an array
-                commentsData.contents.map((comment: ICommentInfo) => (
-                    <S.CommentArea key={comment.id}>
-                        <Comment commentsData={comment} />
-                    </S.CommentArea>
-                ))}
+            {commentsData.contents.map((comment: ICommentInfo) => (
+                <S.CommentArea key={comment.id}>
+                    <Comment commentsData={comment} />
+                </S.CommentArea>
+            ))}
         </>
     );
 };

--- a/src/components/features/contents/comment/commentTheme.tsx
+++ b/src/components/features/contents/comment/commentTheme.tsx
@@ -1,4 +1,4 @@
-import { ICommentResponse } from '@/api/comment';
+import { ICommentInfo } from '@/api/comment';
 import Icon from '@/components/common/icon/Icon';
 import CaptionTag from '@/components/common/text/CaptionTag';
 import ContentTag from '@/components/common/text/CaptionTag';
@@ -7,7 +7,7 @@ import theme from '@/styles/theme';
 
 import * as S from '../style';
 interface ICommentProps {
-    commentsData: ICommentResponse;
+    commentsData: ICommentInfo;
 }
 
 const commentTheme = ({ commentsData }: ICommentProps) => {

--- a/src/components/features/contents/detail/detail.tsx
+++ b/src/components/features/contents/detail/detail.tsx
@@ -1,8 +1,7 @@
 import SubTitle from '@components/common/text/SubTitle';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { useCommentById } from '@/api/comment';
 import { useContentsById } from '@/api/contents';
 import Button from '@/components/common/Button/Button';
 import Divider from '@/components/common/divider/divider';
@@ -11,6 +10,7 @@ import Loading from '@/components/common/loading/Loading';
 import ContentTag from '@/components/common/text/ContentTag';
 import CommentContainer from '@/components/features/contents/comment/commentContainer';
 import TitleContainer from '@/components/features/contents/detail/titleContainer';
+import useComment from '@/hooks/useComment';
 
 import * as S from '../style';
 
@@ -20,24 +20,18 @@ export interface IButtonData {
 }
 
 const ContentContainer = () => {
+    const navigate = useNavigate();
     const { id } = useParams();
 
-    const [inputValue, setInputValue] = useState('');
+    const { data: contentsData } = useContentsById(Number(id));
+    const { commentsData } = useComment(id);
 
-    const handleValueChange = useCallback((value: string) => {
-        setInputValue(value);
-    }, []);
-
-    const navigate = useNavigate();
     const handleMoveComment = useCallback(() => navigate(`/contents/${id}/comment`), []);
 
     const buttonData: Array<IButtonData> = [
         { label: 'Skip', color: 'secondary' },
         { label: 'Buy', color: 'primary' },
     ];
-
-    const { data: contentsData } = useContentsById(Number(id));
-    const { data: commentsData } = useCommentById(Number(id));
 
     return (
         <>
@@ -57,12 +51,7 @@ const ContentContainer = () => {
                             <SubTitle lan='ENG' text={`댓글 ${commentsData.contents.length}`} />
                             <CommentContainer commentsData={commentsData} />
                             <div onClick={handleMoveComment}>
-                                <Input
-                                    placeholder={'댓글을 남겨보세요.'}
-                                    as={'Default'}
-                                    value={inputValue}
-                                    handleOnChange={handleValueChange}
-                                />
+                                <Input placeholder={'댓글을 남겨보세요.'} as={'Default'} />
                             </div>
                         </S.CommentWrapper>
                         <Divider size={6} />

--- a/src/components/features/contents/detail/detail.tsx
+++ b/src/components/features/contents/detail/detail.tsx
@@ -1,12 +1,11 @@
 import SubTitle from '@components/common/text/SubTitle';
 import { useCallback } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { useContentsById } from '@/api/contents';
 import Button from '@/components/common/Button/Button';
 import Divider from '@/components/common/divider/divider';
 import Input from '@/components/common/Input/Input';
-import Loading from '@/components/common/loading/Loading';
 import ContentTag from '@/components/common/text/ContentTag';
 import CommentContainer from '@/components/features/contents/comment/commentContainer';
 import TitleContainer from '@/components/features/contents/detail/titleContainer';
@@ -33,49 +32,48 @@ const ContentContainer = () => {
         { label: 'Buy', color: 'primary' },
     ];
 
+    if (!contentsData) {
+        alert('게시물이 존재하지 않습니다.');
+        return <Navigate to={'/main'} />;
+    }
+
     return (
         <>
-            {contentsData && commentsData ? (
-                <S.Wrapper>
-                    <S.Container>
-                        {/* 타이틀 영역 */}
-                        <TitleContainer contentsData={contentsData} />
-                        <Divider size={6} />
-                        {/* 글 영역 */}
-                        <S.ContentContainer>
-                            <ContentTag as='M' text={contentsData.content} />
-                        </S.ContentContainer>
-                        <Divider color={300} />
-                        {/* 댓글 영역 */}
-                        <S.CommentWrapper>
-                            <SubTitle lan='ENG' text={`댓글 ${commentsData.contents.length}`} />
-                            <CommentContainer commentsData={commentsData} />
-                            <div onClick={handleMoveComment}>
-                                <Input placeholder={'댓글을 남겨보세요.'} as={'Default'} />
-                            </div>
-                        </S.CommentWrapper>
-                        <Divider size={6} />
-                    </S.Container>
-                    {/* 버튼 영역 */}
-                    <S.ButtonWrapper>
-                        {buttonData.map((b, index) => (
-                            <Button
-                                key={index}
-                                label={b.label}
-                                color={b.color as 'secondary' | 'primary'}
-                                styleProps={{
-                                    height: '48px',
-                                    fontSize: '18px',
-                                }}
-                            />
-                        ))}
-                    </S.ButtonWrapper>
-                </S.Wrapper>
-            ) : (
-                <S.LoadingContainer>
-                    <Loading />
-                </S.LoadingContainer>
-            )}
+            <S.Wrapper>
+                <S.Container>
+                    {/* 타이틀 영역 */}
+                    <TitleContainer contentsData={contentsData} />
+                    <Divider size={6} />
+                    {/* 글 영역 */}
+                    <S.ContentContainer>
+                        <ContentTag as='M' text={contentsData.content} />
+                    </S.ContentContainer>
+                    <Divider color={300} />
+                    {/* 댓글 영역 */}
+                    <S.CommentWrapper>
+                        <SubTitle lan='ENG' text={`댓글 ${commentsData.contents.length}`} />
+                        <CommentContainer commentsData={commentsData} />
+                        <div onClick={handleMoveComment}>
+                            <Input placeholder={'댓글을 남겨보세요.'} as={'Default'} />
+                        </div>
+                    </S.CommentWrapper>
+                    <Divider size={6} />
+                </S.Container>
+                {/* 버튼 영역 */}
+                <S.ButtonWrapper>
+                    {buttonData.map((b) => (
+                        <Button
+                            key={b.label}
+                            label={b.label}
+                            color={b.color as 'secondary' | 'primary'}
+                            styleProps={{
+                                height: '48px',
+                                fontSize: '18px',
+                            }}
+                        />
+                    ))}
+                </S.ButtonWrapper>
+            </S.Wrapper>
         </>
     );
 };

--- a/src/components/features/contents/style.ts
+++ b/src/components/features/contents/style.ts
@@ -63,30 +63,38 @@ export const ContentContainer = styled.div`
 
 export const CommentWrapper = styled.div<{ detail?: boolean }>`
     width: 100%;
+
+    padding: ${({ detail }) => (detail ? '20px 0 83px' : '20px 0')};
+
+    position: relative;
+
     display: flex;
     flex-direction: column;
-    padding: 20px 0;
-    position: relative;
-    min-height: ${(props) => props.detail && 'calc(100vh - 56px)'};
 
     & > h4 {
         padding: 0 20px 20px;
     }
 
     & > div:has(input) {
-        width: calc(100% - 40px);
         margin: ${(props) => !props.detail && '10px 20px 0'};
     }
 `;
 
 export const InputArea = styled.div`
-    position: absolute;
-    bottom: -57px;
-    left: 20px;
-    gap: 10px 0;
+    max-width: 475px;
+    width: 100%;
+
+    position: fixed;
+    bottom: 0;
+
     display: flex;
     flex-direction: column;
-    padding: 10px 0;
+
+    background-color: #fff;
+
+    & > div {
+        margin: 10px 20px;
+    }
 `;
 
 export const CommentArea = styled.div<{ paddingLeft?: string }>`
@@ -95,6 +103,9 @@ export const CommentArea = styled.div<{ paddingLeft?: string }>`
     gap: 12px 0;
     padding: ${(props) =>
         props.paddingLeft ? `16px 20px 16px ${props.paddingLeft}` : '16px 20px'};
+
+    border-bottom: 1px solid ${({ theme }) => theme.color.gray[100]};
+
     & > .tagArea {
         width: 100%;
         display: flex;

--- a/src/components/features/contents/style.ts
+++ b/src/components/features/contents/style.ts
@@ -16,11 +16,6 @@ export const Container = styled.div<{ border?: string }>`
     }
 `;
 
-export const LoadingContainer = styled.div`
-    & > div {
-        height: calc(100vh - 56px);
-    }
-`;
 export const ContentArea = styled.div`
     width: 100%;
     margin-bottom: 65px;

--- a/src/hooks/useComment.tsx
+++ b/src/hooks/useComment.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { ICommentAdd, useCommentAdd, useCommentById } from '@/api/comment';
+
+type TBoardId = string | undefined;
+
+const useComment = (id: TBoardId) => {
+    const { data: commentsData } = useCommentById(Number(id));
+    const [inputValue, setinputValue] = useState('');
+    const { mutate: addComment, isError, isSuccess } = useCommentAdd();
+
+    const handleValueChange = useCallback((value: string) => {
+        setinputValue(value);
+    }, []);
+
+    /**
+     * react-query mutation으로 query-key update
+     */
+    const handleCommentSubmit = async () => {
+        const obj: ICommentAdd = {
+            boardId: Number(id),
+            content: inputValue,
+        };
+
+        addComment(obj);
+    };
+
+    /**
+     * mutation이 에러없이 성공했을 경우 input 초기화
+     */
+    useEffect(() => {
+        if (!isError && isSuccess) {
+            setinputValue('');
+        }
+    }, [isError, isSuccess]);
+
+    return {
+        commentsData,
+        inputValue,
+        handleValueChange,
+        handleCommentSubmit,
+    };
+};
+
+export default useComment;

--- a/src/hooks/useComment.tsx
+++ b/src/hooks/useComment.tsx
@@ -19,7 +19,6 @@ const useComment = (id: TBoardId) => {
     const handleCommentSubmit = async () => {
         const obj: ICommentAdd = {
             boardId: Number(id),
-            parentId: 0,
             content: inputValue,
         };
 

--- a/src/hooks/useComment.tsx
+++ b/src/hooks/useComment.tsx
@@ -19,6 +19,7 @@ const useComment = (id: TBoardId) => {
     const handleCommentSubmit = async () => {
         const obj: ICommentAdd = {
             boardId: Number(id),
+            parentId: 0,
             content: inputValue,
         };
 

--- a/src/pages/contents/CommentPage.tsx
+++ b/src/pages/contents/CommentPage.tsx
@@ -1,9 +1,14 @@
+import { Suspense } from 'react';
+
+import Loading from '@/components/common/loading/Loading';
 import Comment from '@/components/features/contents/comment/comment';
 
 const CommentPage = () => {
     return (
         <>
-            <Comment />
+            <Suspense fallback={<Loading />}>
+                <Comment />
+            </Suspense>
         </>
     );
 };

--- a/src/pages/contents/DetailPage.tsx
+++ b/src/pages/contents/DetailPage.tsx
@@ -1,9 +1,14 @@
+import { Suspense } from 'react';
+
+import Loading from '@/components/common/loading/Loading';
 import Detail from '@/components/features/contents/detail/detail';
 
 const DetailPage = () => {
     return (
         <>
-            <Detail />
+            <Suspense fallback={<Loading />}>
+                <Detail />
+            </Suspense>
         </>
     );
 };


### PR DESCRIPTION
## 📖 관련 문서

리엑트쿼리 뮤테이션 : [react-query 의 mutation에 대해 알아보자](https://velog.io/@rookieand/react-query-%EC%9D%98-mutation%EC%97%90-%EB%8C%80%ED%95%B4-%EC%95%8C%EC%95%84%EB%B3%B4%EC%9E%90)
리엑트쿼리 에러처리 : [[Axios] Axios와 useQuery를 함께 사용하며 error 처리하기](https://velog.io/@boyeon_jeong/Axios-Axios%EC%99%80-useQuery%EB%A5%BC-%ED%95%A8%EA%BB%98-%EC%82%AC%EC%9A%A9%ED%95%98%EB%A9%B0-error-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0)
에러 바운더리 : [React Error Boundary를 사용하여 에러 핸들링하기(react-query)](https://www.datoybi.com/error-handling-with-react-query/)

## ✍🏻 변경사항:

1. 기존 댓글 API를 react-query mutation으로 변경했습니다!
2. axios를 감싸고 있던 try/catch를 삭제했습니다!
  - axios의 try/catch로 에러를 관리하지 않고 react-query를 사용하면서 onError를 통해 관리 할 수 있어 삭제했습니다
  - onError를 통해서 Suspense를 사용한 ErrorBoundary를 사용할 수 있어 추후에 적용해보면 좋을거 같습니다!
3. 댓글 API 리스폰 타입이 맞지 않던 부분 수정했습니다!
4. 댓글 서비스와 관련된 API, input을 hook을 만들어 구분했습니다!
5. Suspense를 사용하기 위해 useQuery를 useSuspenseQuery로 변경했습니다! 
  - contents, comment API 로딩관련된 부분 suspense로 fallback loading로 변경했습니다
6. content가 없을 경우 "게시글이 존재하지 않습니다."메시지와 main으로 리다이렉트 하도록 추가했습니다!
  - URL로 접근시에 렌더링이 되지 않는것이 사용자에게 좋지 않을거 같아 검증코드 추가했습니다
7. 코드 정리
  
## 🔍 확인할 목록

- 댓글 상세 스타일 레이아웃 확인
- 댓글 작성 API 정상 동작 확인
- Suspense fallback 컴포넌트 동작 확인
- /comment/999 로 접근시 리다이렉트 확인
